### PR TITLE
Using TCK Tested JDK builds of OpenJDK. 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v1
         with:
-          distribution: 'adopt'
+          distribution: 'zulu'
           java-version: ${{ matrix.java }}
       - name: Cache Maven packages
         uses: actions/cache@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/setup-java@v2
         with:
           java-version: '11'
-          distribution: 'adopt'
+          distribution: 'zulu'
       - name: Publish package capable of targeting H2 in-memory backend
         run: ./mvnw versions:set -DnewVersion=${{ github.event.release.tag_name }} && ./mvnw --batch-mode --update-snapshots -Plog4j2 clean deploy
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ config/*.json
 config/*.sql
 config/application-*.yml
 src/main/resources/application-*.yml
+
+### MacOS
+.DS_Store


### PR DESCRIPTION
The AdoptOpenJDK has been discontinued since July 2021. When using Zulu you get all the latest updated (TCK Tested) builds for all versions of OpenJDK.

Signed-off-by: Carl Dea <carldea@gmail.com>