### PR TITLE
Remove unnecessary blank check during email validation

### DIFF
--- a/src/main/java/io/pivotal/cfapp/domain/EmailValidator.java
+++ b/src/main/java/io/pivotal/cfapp/domain/EmailValidator.java
@@ -5,6 +5,6 @@ import com.sanctionco.jmail.JMail;
 public class EmailValidator {
 
     public static boolean isValid(String email) {
-	return JMail.isValid(email);
+        return JMail.isValid(email);
     }
 }

--- a/src/main/java/io/pivotal/cfapp/domain/EmailValidator.java
+++ b/src/main/java/io/pivotal/cfapp/domain/EmailValidator.java
@@ -1,17 +1,10 @@
 package io.pivotal.cfapp.domain;
 
-import org.apache.commons.lang3.StringUtils;
-
 import com.sanctionco.jmail.JMail;
 
 public class EmailValidator {
 
     public static boolean isValid(String email) {
-
-		if (StringUtils.isBlank(email)) {
-			return false;
-		}
-		return JMail.isValid(email);
-	}
-
+	return JMail.isValid(email);
+    }
 }


### PR DESCRIPTION
Hello! I happened to notice your usage of JMail via GitHub's dependency graph. Just a small suggestion to remove the `StringUtils.isBlank` check - JMail will handle an empty string or a blank string and return `false`.