### PR TITLE
Upgrade GitHub Actions to Node.js 24 ahead of June 2 deadline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: Java CI
 
 on: [push]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,6 +20,9 @@ on:
   schedule:
     - cron: '35 3 * * 6'
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   analyze:
     name: Analyze
@@ -64,7 +67,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -78,7 +81,7 @@ jobs:
     # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -91,6 +94,6 @@ jobs:
     #     ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,10 @@ name: Publish package to GitHub Packages
 on:
   release:
     types: [created]
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   publish-jars:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Opt into Node.js 24 for `actions/checkout@v4`, `actions/setup-java@v4`, and `actions/cache@v4` across all three workflows by setting `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` at the workflow `env` level
- Upgrade `github/codeql-action` from `@v2` to `@v3` in `codeql.yml` — v2 is deprecated and unsupported

## Why now

GitHub will force all JavaScript actions onto Node.js 24 on **June 2, 2026** (12 days away) and remove Node.js 20 from runners on September 16, 2026. CI was already flagging these three actions as deprecated with a warning on every run. This PR eliminates the warning and confirms the actions work correctly under Node.js 24 before the forced migration.

## Changes

| File | Change |
|---|---|
| `ci.yml` | Add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` workflow env |
| `codeql.yml` | Add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` workflow env; `codeql-action` `@v2` → `@v3` |
| `release.yml` | Add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` workflow env |

## Test plan

- [x] CI (`Java CI`) passes with no "may not work as expected" warnings — annotation now reads "are being forced to run on Node.js 24" confirming opt-in is active
- [ ] CodeQL workflow runs on merge to main (scheduled + PR trigger)
- [ ] Release workflow validated on next release cut

🤖 Generated with [Claude Code](https://claude.com/claude-code)